### PR TITLE
Up simple-sign

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,4 +4,4 @@ certifi==2024.7.4
 pydantic==2.8.2
 python-dotenv==1.0.1
 websockets==12.0
-simple-sign==0.0.1rc4
+simple-sign==0.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@
 certifi==2024.7.4
 pydantic==2.8.2
 python-dotenv==1.0.1
-websockets==12.0
+websockets==13.0
 simple-sign==0.0.1


### PR DESCRIPTION
0.0.1 is compatible with Python 3.13 via its Pycardano dependencies.